### PR TITLE
Update dialplan syntax for asterisk 1 6 and upward

### DIFF
--- a/syntaxes/asterisk.tmLanguage
+++ b/syntaxes/asterisk.tmLanguage
@@ -107,7 +107,7 @@
 					<key>5</key>
 					<dict>
 						<key>name</key>
-						<string>constant.character</string>
+						<string>constant.numeric</string>
 					</dict>
 				</dict>
 			</dict>

--- a/syntaxes/asterisk.tmLanguage
+++ b/syntaxes/asterisk.tmLanguage
@@ -50,7 +50,7 @@
 			<!--Extension declaration, patterns, priorities and priority labels-->
 			<dict>
 				<key>match</key>
-				<string>(^exten =>?)( (_[NXZ\d\w\[\]*#\-.!]*|[\d\w:*#]+|[ahiostT]|failed|fax|talk)(,([sn]|\d+|\w+\s*\+\s*\d+|hint)\b(\(([\w\d_-]+)\))?)?)?</string>
+				<string>(^exten\s+=>?)( (_[NXZ\d\w\[\]*#\-.!]*|[\d\w:*#]+|[ahiostT]|failed|fax|talk)(,([sn]|\d+|\w+\s*\+\s*\d+|hint)\b(\(([\w\d_-]+)\))?)?)?</string>
 				<key>captures</key>
 				<dict>
 					<!-- Extension declaration -->
@@ -86,7 +86,7 @@
 			<!-- 'same' keywords continues an extension declaration with priorities and priority labels-->
 			<dict>
 				<key>match</key>
-				<string>(^same  =>?)(\s+(n|\d+)\b(\(([\w\d_-]+)\))?)?</string>
+				<string>(^same\s+=>?)(\s+(n|\d+)\b(\(([\w\d_-]+)\))?)?</string>
 				<key>captures</key>
 				<dict>
 					<!-- Continues an extension declaration -->

--- a/syntaxes/asterisk.tmLanguage
+++ b/syntaxes/asterisk.tmLanguage
@@ -50,7 +50,7 @@
 			<!--Extension declaration, patterns, priorities and priority labels-->
 			<dict>
 				<key>match</key>
-				<string>(^exten =>?)( (_[NXZ\d\w\[\]*#\-.!]*|[ahiostT]|[\d\w*#]+|failed|fax|talk)(,([sn]|\d+|\w+\s*\+\s*\d+|hint)\b(\(([\w\d_-]+)\))?)?)?</string>
+				<string>(^exten =>?)( (_[NXZ\d\w\[\]*#\-.!]*|[\d\w*#]+|[ahiostT]|failed|fax|talk)(,([sn]|\d+|\w+\s*\+\s*\d+|hint)\b(\(([\w\d_-]+)\))?)?)?</string>
 				<key>captures</key>
 				<dict>
 					<!-- Extension declaration -->

--- a/syntaxes/asterisk.tmLanguage
+++ b/syntaxes/asterisk.tmLanguage
@@ -30,7 +30,7 @@
 			<!--Context includes-->
 			<dict>
 				<key>match</key>
-				<string>^(include =>)\s+([\w\d_-]+)</string>
+				<string>^(include =>?)\s+([\w\d_-]+)</string>
 				<key>captures</key>
 				<dict>
 					<key>1</key>
@@ -50,7 +50,7 @@
 			<!--Extension declaration, patterns, priorities and priority labels-->
 			<dict>
 				<key>match</key>
-				<string>(^exten =>)( (_[NXZ\d\w\[\]*#\-.!]*|[ahiostT]|[\d\w*#]+|failed|fax|talk)(,([sn]|\d+|\w+\s*\+\s*\d+|hint)\b(\(([\w\d_-]+)\))?)?)?</string>
+				<string>(^exten =>?)( (_[NXZ\d\w\[\]*#\-.!]*|[ahiostT]|[\d\w*#]+|failed|fax|talk)(,([sn]|\d+|\w+\s*\+\s*\d+|hint)\b(\(([\w\d_-]+)\))?)?)?</string>
 				<key>captures</key>
 				<dict>
 					<!-- Extension declaration -->

--- a/syntaxes/asterisk.tmLanguage
+++ b/syntaxes/asterisk.tmLanguage
@@ -50,7 +50,7 @@
 			<!--Extension declaration, patterns, priorities and priority labels-->
 			<dict>
 				<key>match</key>
-				<string>(^exten =>?)( (_[NXZ\d\w\[\]*#\-.!]*|[\d\w*#]+|[ahiostT]|failed|fax|talk)(,([sn]|\d+|\w+\s*\+\s*\d+|hint)\b(\(([\w\d_-]+)\))?)?)?</string>
+				<string>(^exten =>?)( (_[NXZ\d\w\[\]*#\-.!]*|[\d\w:*#]+|[ahiostT]|failed|fax|talk)(,([sn]|\d+|\w+\s*\+\s*\d+|hint)\b(\(([\w\d_-]+)\))?)?)?</string>
 				<key>captures</key>
 				<dict>
 					<!-- Extension declaration -->

--- a/syntaxes/asterisk.tmLanguage
+++ b/syntaxes/asterisk.tmLanguage
@@ -83,6 +83,35 @@
 				</dict>
 			</dict>
 
+			<!-- 'same' keywords continues an extension declaration with priorities and priority labels-->
+			<dict>
+				<key>match</key>
+				<string>(^same  =>?)(\s+(n|\d+)\b(\(([\w\d_-]+)\))?)?</string>
+				<key>captures</key>
+				<dict>
+					<!-- Continues an extension declaration -->
+					<key>1</key>
+					<dict>
+						<key>name</key>
+						<string>keyword.other</string>
+					</dict>
+
+					<!-- Priority -->
+					<key>2</key>
+					<dict>
+						<key>name</key>
+						<string>constant.numeric</string>
+					</dict>
+
+					<!-- Priority label -->
+					<key>5</key>
+					<dict>
+						<key>name</key>
+						<string>constant.character</string>
+					</dict>
+				</dict>
+			</dict>
+
 			<!--Applications-->
 			<dict>
 				<key>match</key>


### PR DESCRIPTION
Contribution to make this extension recognize wider type of asterisk dialplan :

1. Recognize both `exten =>` and  `exten =` syntax

Asterisk recognizes both 
```
exten => 6123,1,do something
exten => 6123,n,do something else
```
and
```
exten = 6123,1,do something
exten = 6123,n,do something else
```
as valid dialplan.

2. add support of keyword `same` which was introduced in asterisk 1.6.2
(see for example [Piority label section](https://wiki.asterisk.org/wiki/display/AST/Contexts%2C+Extensions%2C+and+Priorities#Contexts,Extensions,andPriorities-Applicationcalls))

so one can write : 
```
exten = 6123,1,do something
exten = 6123,n,do something else
```
or
```
exten = 6123,1,do something
same  =      n,do something else
```

3. and fix a regexp to correctly match extension beginning by one of the letters ahiostT

4. and add character `:` in allowed extension characters

Thanks for your work